### PR TITLE
Pin versions

### DIFF
--- a/lima-vm/aya-lab.yaml
+++ b/lima-vm/aya-lab.yaml
@@ -102,10 +102,10 @@ provision:
       # https://aya-rs.dev/book/start/development/
       set -eux -o pipefail
       rustup install stable
-      rustup toolchain add nightly
-      rustup toolchain install nightly --component rust-src
+      rustup toolchain add nightly-2024-07-23
+      rustup toolchain install nightly-2024-07-23 --component rust-src
       cargo install cargo-generate
-      cargo install --no-default-features bpf-linker
+      cargo install --no-default-features bpf-linker@0.9.12
       cargo install bindgen-cli
       cargo install --git https://github.com/aya-rs/aya -- aya-tool
 

--- a/tracepoint-sched-process-exec/xtask/src/build_ebpf.rs
+++ b/tracepoint-sched-process-exec/xtask/src/build_ebpf.rs
@@ -42,7 +42,7 @@ pub struct Options {
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("ebpf");
     let target: String = format!("--target={}", opts.target);
-    let mut args: Vec<&str> = vec!["+nightly", "build", target.as_str(), "-Z", "build-std=core"];
+    let mut args: Vec<&str> = vec!["+nightly-2024-07-23", "build", target.as_str(), "-Z", "build-std=core"];
     if opts.release {
         args.push("--release");
     }
@@ -53,7 +53,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
 
     let status = Command::new("cargo")
         .current_dir(dir)
-        .env("RUSTFLAGS", "-C debuginfo=1 -C link-arg=--btf")
         .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()


### PR DESCRIPTION
As of Aug 11 2024, latest nightly rust doesn't compile ebpf successfully. 

error sample.
```
 = note: 02:01:19 ␛[0m␛[31m[ERROR] ␛[0mllvm: Invalid attribute group entry (Producer: 'LLVM19.1.0-rust-1.82.0-nightly' Reader: 'LLVM 18.1.8')
          error: failure linking module /Users/yukinakamura/Projects/rust-learning/aya-lab/tracepoint-sched-process-exec/ebpf/../target/bpfel-unknown-none/debug/deps/trace_sched_process_exec-6640c227f1f7bc40.trace_sched_process_exec.9809054764b5629f-...          02:01:19 ␛[0m␛[34m[INFO] ␛[0mLLVM command line: ["bpf-linker", "--cold-callsite-rel-freq=0", "--bpf-expand-memcpy-in-order"]
```